### PR TITLE
Update run-fourmolu action to v13

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -77,7 +77,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Fourmolu
-        uses: haskell-actions/run-fourmolu@015e6ed9db2b3f344482792d42b7317c764eb30f # v12
+        uses: haskell-actions/run-fourmolu@1b9df64b784203126500372730b9725c97e4040b # v13
         with:
           pattern: |
             lib/**/*.hs


### PR DESCRIPTION
## Summary
Updates the `haskell-actions/run-fourmolu` GitHub Action from v12 to v13.

## Changes
- Updated the `run-fourmolu` action commit hash from `015e6ed9db2b3f344482792d42b7317c764eb30f` to `1b9df64b784203126500372730b9725c97e4040b`
- Action version bumped from v12 to v13

## Details
This update brings the latest version of the Fourmolu code formatter action, which may include bug fixes, performance improvements, or new features in the v13 release.

https://claude.ai/code/session_01NqeG8BbXAUqrCDuvNq5hD2